### PR TITLE
Removed link to INCF software center and added info from that page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 ## What is libneurosim?
 
-libneurosim is a general library that provides interfaces for neuronal
-simulators.
+libneurosim is a general library that provides interfaces and common
+utility code for neuronal simulators.
+
+Currently it provides the ConnectionGenerator interface.
+
+The ConnectionGenerator API is a standard interface supporting
+efficient generation of network connectivity during model setup in
+neuronal network simulators. It is intended as an abstraction
+isolating both sides of the API: any simulator can use a given
+connection generator and a given simulator can use any library
+providing the ConnectionGenerator interface. It was initially
+developed to support the use of libcsa from NEST.
 
 ## Required external packages
 
@@ -10,10 +20,8 @@ simulator.
 
 ## Where to find more information
 
-Information about libneurosim can be found on the MUSIC home page at
-the INCF Software Center:
-
-http://software.incf.org/software/libneurosim
+The ConnectionGenerator API is described in
+[Djurfeldt et al. (2014)](http://dx.doi.org/10.3389/fninf.2014.00043).
 
 ## Submitting bug reports
 
@@ -23,8 +31,7 @@ Bug reports can be filed as issues on GitHub.
 
 Currently, libneurosim is only supported by the
 [NEST](http://github.com/nest/nest-simulator) simulator and only
-provides the [Connection Generator
-Interface](http://dx.doi.org/10.3389/fninf.2014.00043).
+provides the Connection Generator Interface.
 
 This should change.
 


### PR DESCRIPTION
Since INCF Software center is going down, we should remove any dependencies on it.