### PR TITLE
Extend build config to ask for Python version to use

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce configure.
-AC_INIT(libneurosim, 1.0.0)
+AC_INIT(libneurosim, 1.0.0, [https://github.com/INCF/libneurosim/issues])
 AM_INIT_AUTOMAKE
 AM_CONFIG_HEADER([config.h])
 AM_MAINTAINER_MODE
@@ -155,12 +155,16 @@ else
 fi
 # further processing of distributed case below (see NS_NEW_PATH_MPI)
 
-AM_PATH_PYTHON
+dnl Choose Python version
+AC_ARG_WITH([python], [AS_HELP_STRING([--with-python], [python version to use 2 or 3])], [], [with_python=no])
+AM_PATH_PYTHON(["$with_python"])
 AM_CONDITIONAL([HAVE_PYTHON], [test "$PYTHON" != [:]])
 if test $PYTHON != [:]; then
-  PYTHON_INCLUDE=`$PYTHON -c 'from distutils import sysconfig;\
-  			      print (sysconfig.get_python_inc ())'`
+    PYTHON_INCLUDE=`$PYTHON -c 'from distutils import sysconfig;\
+        print (sysconfig.get_python_inc ())'`
 fi
+dnl set this to use in the makefile
+AM_CONDITIONAL([PY3], [test "x$with_python" = x3 ])
 
 NS_SET_CFLAGS
 CFLAGS=

--- a/libpyneurosim/Makefile.am
+++ b/libpyneurosim/Makefile.am
@@ -4,9 +4,31 @@ AUTOMAKE_OPTIONS = subdir-objects
 
 lib_LTLIBRARIES =
 if HAVE_PYTHON
-lib_LTLIBRARIES += libpyneurosim.la
-endif
+if PY3
+lib_LTLIBRARIES += libpy3neurosim.la
+libpy3neurosim_la_SOURCES = \
+  pyneurosim.cpp \
+  pyneurosim.h
 
+libpy3neurosim_la_HEADERS = \
+  pyneurosim.h
+
+libpy3neurosim_la_CXXFLAGS = -I@PYTHON_INCLUDE@ -I$(srcdir)/../libneurosim/conngen
+libpy3neurosim_la_LDFLAGS = $(top_builddir)/libneurosim/libneurosim.la
+libpy3neurosim_ladir = $(includedir)/neurosim
+else
+lib_LTLIBRARIES += libpy2neurosim.la libpyneurosim.la
+libpy2neurosim_la_SOURCES = \
+  pyneurosim.cpp \
+  pyneurosim.h
+
+libpy2neurosim_la_HEADERS = \
+  pyneurosim.h
+
+libpy2neurosim_la_CXXFLAGS = -I@PYTHON_INCLUDE@ -I$(srcdir)/../libneurosim/conngen
+libpy2neurosim_la_LDFLAGS = $(top_builddir)/libneurosim/libneurosim.la
+libpy2neurosim_ladir = $(includedir)/neurosim
+# generate versionless version for backwards compatibility
 libpyneurosim_la_SOURCES = \
   pyneurosim.cpp \
   pyneurosim.h
@@ -15,7 +37,7 @@ libpyneurosim_la_HEADERS = \
   pyneurosim.h
 
 libpyneurosim_la_CXXFLAGS = -I@PYTHON_INCLUDE@ -I$(srcdir)/../libneurosim/conngen
-
 libpyneurosim_la_LDFLAGS = $(top_builddir)/libneurosim/libneurosim.la
-
 libpyneurosim_ladir = $(includedir)/neurosim
+endif
+endif


### PR DESCRIPTION
The user *must* specify what version of Python to use. Otherwise,
configure will not complete. This is to ensure that the user is aware of
the Python version in use.

For Python3: libpy3neurosim
For Python2: libpy2neurosim, and libpyneurosim for backwards
compatibility

Fixes #7

Unfortunately, it does not seem like Autotools permits generating both Py2/3 at once (I don't know if any other toolchain allows that either).