### PR TITLE
Fix directory name

### DIFF
--- a/libpyneurosim/Makefile.am
+++ b/libpyneurosim/Makefile.am
@@ -13,8 +13,8 @@ libpy3neurosim_la_SOURCES = \
 libpy3neurosim_la_HEADERS = \
   pyneurosim.h
 
-libpy3neurosim_la_CXXFLAGS = -I@PYTHON_INCLUDE@ -I$(srcdir)/../libneurosim/conngen
-libpy3neurosim_la_LDFLAGS = $(top_builddir)/libneurosim/libneurosim.la
+libpy3neurosim_la_CXXFLAGS = -I@PYTHON_INCLUDE@ -I$(srcdir)/../neurosim/conngen
+libpy3neurosim_la_LDFLAGS = $(top_builddir)/neurosim/libneurosim.la
 libpy3neurosim_ladir = $(includedir)/neurosim
 else
 lib_LTLIBRARIES += libpy2neurosim.la libpyneurosim.la
@@ -25,8 +25,8 @@ libpy2neurosim_la_SOURCES = \
 libpy2neurosim_la_HEADERS = \
   pyneurosim.h
 
-libpy2neurosim_la_CXXFLAGS = -I@PYTHON_INCLUDE@ -I$(srcdir)/../libneurosim/conngen
-libpy2neurosim_la_LDFLAGS = $(top_builddir)/libneurosim/libneurosim.la
+libpy2neurosim_la_CXXFLAGS = -I@PYTHON_INCLUDE@ -I$(srcdir)/../neurosim/conngen
+libpy2neurosim_la_LDFLAGS = $(top_builddir)/neurosim/libneurosim.la
 libpy2neurosim_ladir = $(includedir)/neurosim
 # generate versionless version for backwards compatibility
 libpyneurosim_la_SOURCES = \


### PR DESCRIPTION
The code added to [`libpyneurosim/Makefile.am`](https://github.com/INCF/libneurosim/commit/b386b8eaf87d21c45b61363d76aa701fd52283ac#diff-b36e373f2c2b3aff11cd72d8370dda632f606395ea5f372df7c62d351acf8ac2) in b386b8eaf87d21c45b61363d76aa701fd52283ac introduced the use of an erroneous directory name `$(top_builddir)/libneurosim`, which should have been `$(top_builddir)/neurosim`.

This PR corrects the directory name and thus fixes #19.